### PR TITLE
Fixed Link and Made Tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,10 +75,10 @@
       
       <div class="tab win">
         <ol>
-          <li><p>Open this link, click on your platform (most likely x64), click on Artifacts and finally download the zip on the top of the list.</p></li>
+          <li><p>Open <a href="https://ci.appveyor.com/project/paulsapps/alive-reversing?branch=master">this link</a>, click on your platform (most likely x64), click on Artifacts and finally download the zip on the top of the list.</p></li>
           <li><p>Unzip it somewhere.</p></li>
           <li><p>Navigate to where you installed the game (GOG asks you where you want to install it, with
-              Steam you can right click on the game, select Manage -> Browse local files)</p></li>
+              Steam you can right click on the game, select Manage -> Browse local files).</p></li>
           <li><p>Copy AliveExeAE.exe and SDL2.dll to the game's folder from the unzipped folder.</p></li>
           <li><p>Run the game by launching AliveExeAE.exe.</p></li>
         </ol>
@@ -97,7 +97,7 @@
       <div class="tab manual_linux">
         <ol>
           <li><p><code>git clone https://github.com/AliveTeam/alive_reversing.git --recursive</code></p></li>
-          <li><p>Install the development libraries for SDL2 using your distribution's package manager (<code>libsdl2-dev</code> on Ubuntu/Debian, <code>sdl2</code> on Arch).</p></li>
+          <li><p>Install the development libraries for SDL2 using your distribution's package manager: <code>libsdl2-dev</code> on Ubuntu/Debian, <code>sdl2</code> on Arch, <code>SDL2-devel</code> on Fedora, etc.</p></li>
           <li><p>Navigate to the cloned repository and call <code>cmake -B build -S .</code> (the dot is important).</p></li>
           <li><p>Once this is done, you can issue <code>make</code>.</p></li>
           <li><p>Copy <code>build/Source/AliveExe/AliveExeAE</code> into the game's folder.</p></li>
@@ -111,7 +111,7 @@
     <div>
       <div>
         <h2>The Future</h2>
-        <p>After the engine is fully reimplemented, the focus will shift on new features that which were never part of the original.</p>
+        <p>After the engine is fully reimplemented, the focus will shift to adding new features that were never part of the original.</p>
         <ul>
           <li>More platforms (<a href="https://www.youtube.com/watch?v=R3p4Q9D_KYo">sneak peek</a>).</li>
           <li>Subtitles for cutscenes.</li>


### PR DESCRIPTION
Fixed link in Windows instructions. Added Fedora SDL2 package name to the Manual (Linux) instructions. Tweaked sentence in Support Us section.