### PR TITLE
updated build instructions for linux(manual install) paragraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,9 +173,10 @@
           <ol>
             <li><p><code>git clone https://github.com/AliveTeam/alive_reversing.git --recursive</code></p></li>
             <li><p>Install the development libraries for SDL2 using your distribution's package manager: <code>libsdl2-dev</code> on Ubuntu/Debian, <code>sdl2</code> on Arch, <code>SDL2-devel</code> on Fedora, etc.</p></li>
-            <li><p>Navigate to the cloned repository and call <code>cmake -B build -S .</code> (the dot is important).</p></li>
-            <li><p>Once this is done, you can issue <code>make</code>.</p></li>
-            <li><p>Copy <code>build/Source/relive/relive</code> into the respective game's folder.</p></li>
+            <li><p>Navigate to the cloned repository and <code>cd build</code> <code>cmake -S .. -B .</code> (the last dot is important).</p></li>
+            <li><p>Once this is done, you can issue <code>make -j$(nproc) </code>.</p></li>
+            <li><p>Copy <code>build/Source/relive/relive</code> binary into the respective game's folder.</p></li>
+            <li><p>You can optionally install the package using make install or create a Debian-compatible package using <code>cpack -G DEB </code>.</p></li>
             <li><p>Run the game by launching the newly copied executable.</p></li>
           </ol>
         </div>


### PR DESCRIPTION
The build instructions for linux on the website are out of date, but not on the github readme. I updated the relevant parts.