### PR TITLE
Update relive URL's and artifact file names

### DIFF
--- a/fetch_links.js
+++ b/fetch_links.js
@@ -21,10 +21,10 @@ function setDate(json, accessor, selector) {
 
 function replaceURL(link, assets) {
 	const fileNames = new Map([
-		["deb", "RELIVE-Linux.deb.zip"],
-		["win32", "RELIVE_Windows_Binaries_Lite_Debug_x86.zip"],
-		["win64", "RELIVE_Windows_Binaries_Lite_Debug_x64.zip"],
-		["mac", "RELIVE-MacOSX.dmg.zip"],
+		["deb", "Linux-Debug-relive.deb.zip"],
+		["win32", "Windows32-Debug-relive-binaries.zip"],
+		["win64", "Windows64-Debug-relive-binaries.zip"],
+		["mac", "macOS-Debug-relive.dmg.zip"],
 
 		["editor_win32", "Editor_Release_x86"],
 		["editor_win64", "Editor_Release_x64"],

--- a/index.html
+++ b/index.html
@@ -125,14 +125,14 @@
             </div>
 
             <div class="links">
-              <a href="https://ci.appveyor.com/api/projects/paulsapps/alive-reversing/artifacts/build/RELIVE_Windows_Binaries_Lite_Debug_x64.zip?branch=beta&job=Windows64">Windows</a>
+              <a href="https://github.com/AliveTeam/alive_reversing/releases/download/v0.0.1-beta/Windows64-Debug-relive-binaries.zip">Windows</a>
 
               <div>
-                <a href="https://ci.appveyor.com/api/projects/paulsapps/alive-reversing/artifacts/build/RELIVE_Windows_Binaries_Lite_Debug_x86.zip?branch=beta&job=Windows32">Windows 32-bit</a>
-                <a href="https://ci.appveyor.com/api/projects/paulsapps/alive-reversing/artifacts/build/relive-0.1-Darwin.dmg?branch=beta&job=MacOS">MacOSX</a>
+                <a href="https://github.com/AliveTeam/alive_reversing/releases/download/v0.0.1-beta/Windows32-Debug-relive-binaries.zip">Windows 32-bit</a>
+                <a href="https://github.com/AliveTeam/alive_reversing/releases/tag/v0.0.1-beta">MacOSX</a>
               </div>
 
-              <a href="https://ci.appveyor.com/api/projects/paulsapps/alive-reversing/artifacts/build/relive-0.1-Linux.deb?branch=beta&job=Linux">Debian</a>
+              <a href="https://github.com/AliveTeam/alive_reversing/releases/download/v0.0.1-beta/Linux-Debug-relive.deb.zip">Debian</a>
               <a href="https://github.com/AliveTeam/alive_reversing/tree/beta">Source</a>
             </div>
           </div>


### PR DESCRIPTION
- Updates the relive stable artifact names
- Hardcode the relive beta artifact download links for now (better than using appveyor because it deletes artifacts every month)

Note: macOS artifacts are currently not available so the download button just points to the release page until it's available again.